### PR TITLE
Fix help for output file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ optional arguments:
   --format FORMAT      output file format : 
                        lcov        : lcov compatible format (default)
                        json-legacy : legacy json format
-                       lcov        : simpler json format
+                       json        : simpler json format
   --xml-dir XML_DIR    path to generated doxygen XML directory
   --output OUTPUT      destination output file (- for stdout)
   --src-dir ROOT_DIR   root source directory used to match prefix forrelative path generated files

--- a/coverxygen/__main__.py
+++ b/coverxygen/__main__.py
@@ -34,7 +34,7 @@ def main():
                         help="output file format : \n"
                         "lcov        : lcov compatible format (default)\n"
                         "json-legacy : legacy json format\n"
-                        "lcov        : simpler json format\n",
+                        "json        : simpler json format\n",
                         default="lcov")
   l_parser.add_argument("--xml-dir",
                         action="store",


### PR DESCRIPTION
This commit removes a duplicate value in the help text for the
`--format` argument and replaces it with the correct value.