### PR TITLE
Adds tracking of enum values

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ optional arguments:
                         - all       : all above
   --kind KIND          comma-separated list of items' type to include : 
                         - enum      : enum definitions
+                        - enumvalue : enumvalue definitions
+                                      Note: a single undocumented enumvalue will mark
+                                      the containing enum as undocumented
                         - friend    : friend declarations
                         - typedef   : typedef definitions
                         - variable  : variable definitions

--- a/coverxygen/__init__.py
+++ b/coverxygen/__init__.py
@@ -278,11 +278,11 @@ class Coverxygen(object):
       for c_item in c_data:
         l_line = c_item["line"]
         if not c_item["documented"]:
-          l_line[l_line] = 0
+          l_lines[l_line] = 0
         elif not l_line in l_lines:
           l_lines[l_line] = 1
-      for c_line, c_lineValue in l_lines:
-        p_stream.write("DA:%d,%d\n" % (c_line, c_lineValue))
+      for c_line in l_lines:
+        p_stream.write("DA:%d,%d\n" % (c_line, l_lines[c_line]))
       p_stream.write("end_of_record\n")
 
 # Local Variables:

--- a/coverxygen/__init__.py
+++ b/coverxygen/__init__.py
@@ -92,6 +92,11 @@ class Coverxygen(object):
     return None
 
   @staticmethod
+  def extract_kind(p_node):
+    l_kind = p_node.get("kind")
+    return l_kind
+
+  @staticmethod
   def extract_documented(p_node):
     for c_key in ["briefdescription", "detaileddescription", "inbodydescription"]:
       l_node = p_node.find("./%s" % c_key)
@@ -125,7 +130,7 @@ class Coverxygen(object):
 
   def should_filter_out(self, p_node, p_file, p_line):
     l_scope  = p_node.get('prot')
-    l_kind   = p_node.get('kind')
+    l_kind   = self.extract_kind(p_node)
     if l_scope is None:
       l_scope = "public"
     if (not l_scope in self.m_scope) or (not l_kind in self.m_kind):
@@ -135,18 +140,45 @@ class Coverxygen(object):
     self.verbose("found symbol of type %s at %s:%d", l_kind, p_file, p_line)
     return False
 
+  def process_enumValue(self, p_node, p_enum):
+    l_name         = self.extract_name(p_node)
+    l_isDocumented = self.extract_documented(p_node)
+    l_enumValue = {
+      "symbol"    : l_name,
+      "documented": l_isDocumented,
+      # enum values do not have location information, so we use the location
+      # of the surrounding enum
+      "line"      : p_enum["line"],
+      "file"      : p_enum["file"]
+    }
+    return l_enumValue
+
+  def process_enum(self, p_node, p_enum):
+    if not 'enumvalue' in self.m_kind:
+      return []
+    l_enumValueNodes = p_node.findall("./enumvalue")
+    l_enumValues = []
+    for c_enumValueNode in l_enumValueNodes:
+      l_enumValues.append(self.process_enumValue(c_enumValueNode, p_enum))
+    return l_enumValues
+
   def process_symbol(self, p_node, p_filePath):
     l_name         = self.extract_name(p_node)
+    l_kind         = self.extract_kind(p_node)
     l_isDocumented = self.extract_documented(p_node)
     l_file, l_line = self.extract_location(p_node, p_filePath, self.m_rootDir)
     if self.should_filter_out(p_node, l_file, l_line):
-      return {}
-    return {
+      return []
+    l_symbol = {
       "symbol"     : l_name,
       "documented" : l_isDocumented,
       "line"       : l_line,
       "file"       : l_file
     }
+    l_symbols = [l_symbol]
+    if l_kind == 'enum':
+      l_symbols.extend(self.process_enum(p_node, l_symbol))
+    return l_symbols
 
   @staticmethod
   def merge_symbols(p_results, p_symbols):
@@ -165,8 +197,7 @@ class Coverxygen(object):
     l_xmlNodes  = l_xmlDoc.findall("./compounddef//memberdef")
     l_xmlNodes += l_xmlDoc.findall("./compounddef")
     for c_def in l_xmlNodes:
-      l_symbol = self.process_symbol(c_def, p_filePath)
-      l_symbols.append(l_symbol)
+      l_symbols.extend(self.process_symbol(c_def, p_filePath))
     self.merge_symbols(p_results, l_symbols)
 
   def process_index(self, p_xmlDoc):
@@ -226,11 +257,15 @@ class Coverxygen(object):
   def output_print_lcov(p_stream, p_results):
     for c_file, c_data in p_results.items():
       p_stream.write("SF:%s\n" % c_file)
+      l_lines = {}
       for c_item in c_data:
-        l_value = 1
+        l_line = c_item["line"]
         if not c_item["documented"]:
-          l_value = 0
-        p_stream.write("DA:%d,%d\n" % (c_item["line"], l_value))
+          l_line[l_line] = 0
+        elif not l_line in l_lines:
+          l_lines[l_line] = 1
+      for c_line, c_lineValue in l_lines:
+        p_stream.write("DA:%d,%d\n" % (c_line, c_lineValue))
       p_stream.write("end_of_record\n")
 
 # Local Variables:

--- a/coverxygen/__main__.py
+++ b/coverxygen/__main__.py
@@ -65,6 +65,9 @@ def main():
                         action="store",
                         help="comma-separated list of items' type to include : \n"
                         " - enum      : enum definitions \n"
+                        " - enumvalue : enumvalue definitions\n"
+                        "               Note: a single undocumented enumvalue will mark\n"
+                        "               the containing enum as undocumented\n"
                         " - typedef   : typedef definitions\n"
                         " - variable  : variable definitions\n"
                         " - function  : function definitions\n"
@@ -81,7 +84,7 @@ def main():
   if l_result.scope == "all":
     l_result.scope = "public,protected,private"
   if l_result.kind == "all":
-    l_result.kind = "enum,typedef,variable,function,class,struct,define,file,namespace,page"
+    l_result.kind = "enum,enumvalue,typedef,variable,function,class,struct,define,file,namespace,page"
 
   l_result.scope = l_result.scope.split(",")
   l_result.kind  = l_result.kind.split(",")

--- a/coverxygen/test/data/enum.xml
+++ b/coverxygen/test/data/enum.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="compound.xsd" version="1.8.14">
+  <compounddef
+    id="class_my_enum_class"
+    kind="class" language="C++" prot="public" abstract="yes">
+    <compoundname>MyEnumClass
+    </compoundname>
+    <sectiondef kind="public-type">
+      <memberdef kind="enum"
+        id="class_my_enum_class_1a4bffd5affc2abeba8ed3af3c2fd81ff4"
+        prot="public" static="no" strong="no">
+        <type></type>
+        <name>MyEnum</name>
+        <enumvalue
+          id="class_my_enum_class_1a4bffd5affc2abeba8ed3af3c2fd81ff4a38a848620f5abd0aca2849e48869ebc1"
+          prot="public">
+          <name>Enum_Value_1</name>
+          <initializer>= 100</initializer>
+          <briefdescription>
+            <para>A documented enum value. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue
+          id="class_my_enum_class_1a4bffd5affc2abeba8ed3af3c2fd81ff4a9f10ec475af2abef02c2eed24a376828"
+          prot="public">
+          <name>Enum_Value_2</name>
+          <initializer>= -1</initializer>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+          <para>An enumeration. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="MyEnumClass.hpp" line="466" column="1" bodyfile="MyEnumClass.hpp" bodystart="465" bodyend="475" />
+      </memberdef>
+    </sectiondef>
+  </compounddef>
+</doxygen>


### PR DESCRIPTION
Currently, the coverage of enum values is not tracked. This PR adds tracking of enum values.

However, Doxygen does not generate location information for enum values. To work around this, I use the location information of the enum.
That required a change in the way the coverage is calculated for the lcov format:
it now supports multiple symbols with identical location information and the coverage will be set to 0 if any of the symbols on the given location is not documented.
So this now means that the enum itself as well as all its enum values need to be documented for the enum to be marked as "covered".