### PR TITLE
Summary output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ optional arguments:
                         - all       : all above
   --kind KIND          comma-separated list of items' type to include : 
                         - enum      : enum definitions
+                        - enumvalue : enumvalue definitions
+                                      Note: a single undocumented enumvalue will mark
+                                      the containing enum as undocumented
                         - friend    : friend declarations
                         - typedef   : typedef definitions
                         - variable  : variable definitions

--- a/README.md
+++ b/README.md
@@ -22,11 +22,18 @@
 First, run doxygen with XML output on your project, Coverxygen will read generated file and produce an lcov compatible output.
 Finally, run `lcov` or `genhtml` to produce the coverage output.
 
+Alternatively, Coverxygen can also calculate the coverage and print a summary table when given the option `--format summary`.
+
 ## Prerequisites
 
-Coverxygen relies on both doxygen (to generate the documentation information) and lcov to generate the reports.
+Coverxygen relies on doxygen to generate the documentation information. 
 ```bash
-sudo apt-get install doxygen lcov
+sudo apt-get install doxygen
+```
+
+Additionally, if you want to generate coverage reports using lcov, this needs to be installed as well:
+```bash
+sudo apt-get install lcov
 ```
 
 ## Installation
@@ -78,22 +85,23 @@ optional arguments:
                        lcov        : lcov compatible format (default)
                        json-legacy : legacy json format
                        json        : simpler json format
+                       summary     : textual summary table format
   --xml-dir XML_DIR    path to generated doxygen XML directory
   --output OUTPUT      destination output file (- for stdout)
-  --src-dir ROOT_DIR   root source directory used to match prefix forrelative path generated files
+  --src-dir ROOT_DIR   root source directory used to match prefix for relative path generated files
   --prefix PREFIX      keep only file matching given path prefix
-  --scope SCOPE        comma-separated list of items' scope to include : 
-                        - public    : public member elements
+  --scope SCOPE        comma-separated list of item scopes to include : 
+                        - public    : public member and global elements
                         - protected : protected member elements
                         - private   : private member elements
                         - all       : all above
-  --kind KIND          comma-separated list of items' type to include : 
+  --kind KIND          comma-separated list of item types to include : 
                         - enum      : enum definitions
-                        - enumvalue : enumvalue definitions
-                                      Note: a single undocumented enumvalue will mark
+                        - enumvalue : enum value definitions
+                                      Note: a single undocumented enum value will mark
                                       the containing enum as undocumented
                         - friend    : friend declarations
-                        - typedef   : typedef definitions
+                        - typedef   : type definitions
                         - variable  : variable definitions
                         - function  : function definitions
                         - signal    : Qt signal definitions
@@ -102,17 +110,15 @@ optional arguments:
                         - struct    : struct definitions
                         - union     : union definitions
                         - define    : define definitions
-                        - file      : file definitions
+                        - file      : files
                         - namespace : namespace definitions
-                        - page      : page definitions
+                        - page      : documentation pages
                         - all       : all above
 ```
 
-
-
 ## Run lcov or genhtml
 
-If you want an simple console output :
+lcov can be used to generate a simple console output based on documented lines :
 ```
 lcov --summary doc-coverage.info
 ```
@@ -125,7 +131,29 @@ genhtml --no-function-coverage --no-branch-coverage doc-coverage.info -o .
 
 ## Results
 
-Summary
+### `summary` Format
+
+```
+Classes    :  90.5% (38/42)
+Defines    :   0.0% (0/2)
+Enum Values:  12.3% (8/65)
+Enums      :  75.0% (3/4)
+Files      :   8.3% (2/24)
+Functions  :  64.8% (175/270)
+Namespaces :  75.0% (6/8)
+Pages      : 100.0% (7/7)
+Signals    :  83.3% (5/6)
+Slots      :  28.6% (2/7)
+Structs    :  80.0% (4/5)
+Typedefs   :  39.1% (9/23)
+Variables  :  20.0% (8/40)
+-----------------------------------
+Total      :  53.1% (267/503)
+```
+
+### lcov
+
+Overview
 
 ![Summary](./docs/coverage-summary.png)
 

--- a/coverxygen/__init__.py
+++ b/coverxygen/__init__.py
@@ -278,11 +278,11 @@ class Coverxygen(object):
       for c_item in c_data:
         l_line = c_item["line"]
         if not c_item["documented"]:
-          l_line[l_line] = 0
+          l_lines[l_line] = 0
         elif not l_line in l_lines:
           l_lines[l_line] = 1
-      for c_line, c_lineValue in l_lines:
-        p_stream.write("DA:%d,%d\n" % (c_line, c_lineValue))
+      for c_line in l_lines:
+        p_stream.write("DA:%d,%d\n" % (c_line, l_lines[c_line]))
       p_stream.write("end_of_record\n")
 
 # Local Variables:

--- a/coverxygen/__init__.py
+++ b/coverxygen/__init__.py
@@ -92,6 +92,11 @@ class Coverxygen(object):
     return None
 
   @staticmethod
+  def extract_kind(p_node):
+    l_kind = p_node.get("kind")
+    return l_kind
+
+  @staticmethod
   def extract_documented(p_node):
     for c_key in ["briefdescription", "detaileddescription", "inbodydescription"]:
       l_node = p_node.find("./%s" % c_key)
@@ -125,7 +130,7 @@ class Coverxygen(object):
 
   def should_filter_out(self, p_node, p_file, p_line):
     l_scope  = p_node.get('prot')
-    l_kind   = p_node.get('kind')
+    l_kind   = self.extract_kind(p_node)
     if l_scope is None:
       l_scope = "public"
     if (not l_scope in self.m_scope) or (not l_kind in self.m_kind):
@@ -135,18 +140,45 @@ class Coverxygen(object):
     self.verbose("found symbol of type %s at %s:%d", l_kind, p_file, p_line)
     return False
 
+  def process_enumValue(self, p_node, p_enum):
+    l_name         = self.extract_name(p_node)
+    l_isDocumented = self.extract_documented(p_node)
+    l_enumValue = {
+      "symbol"    : l_name,
+      "documented": l_isDocumented,
+      # enum values do not have location information, so we use the location
+      # of the surrounding enum
+      "line"      : p_enum["line"],
+      "file"      : p_enum["file"]
+    }
+    return l_enumValue
+
+  def process_enum(self, p_node, p_enum):
+    if not 'enumvalue' in self.m_kind:
+      return []
+    l_enumValueNodes = p_node.findall("./enumvalue")
+    l_enumValues = []
+    for c_enumValueNode in l_enumValueNodes:
+      l_enumValues.append(self.process_enumValue(c_enumValueNode, p_enum))
+    return l_enumValues
+
   def process_symbol(self, p_node, p_filePath):
     l_name         = self.extract_name(p_node)
+    l_kind         = self.extract_kind(p_node)
     l_isDocumented = self.extract_documented(p_node)
     l_file, l_line = self.extract_location(p_node, p_filePath, self.m_rootDir)
     if self.should_filter_out(p_node, l_file, l_line):
-      return {}
-    return {
+      return []
+    l_symbol = {
       "symbol"     : l_name,
       "documented" : l_isDocumented,
       "line"       : l_line,
       "file"       : l_file
     }
+    l_symbols = [l_symbol]
+    if l_kind == 'enum':
+      l_symbols.extend(self.process_enum(p_node, l_symbol))
+    return l_symbols
 
   @staticmethod
   def merge_symbols(p_results, p_symbols):
@@ -165,8 +197,7 @@ class Coverxygen(object):
     l_xmlNodes  = l_xmlDoc.findall("./compounddef//memberdef")
     l_xmlNodes += l_xmlDoc.findall("./compounddef")
     for c_def in l_xmlNodes:
-      l_symbol = self.process_symbol(c_def, p_filePath)
-      l_symbols.append(l_symbol)
+      l_symbols.extend(self.process_symbol(c_def, p_filePath))
     self.merge_symbols(p_results, l_symbols)
 
   def process_index(self, p_xmlDoc):
@@ -226,11 +257,15 @@ class Coverxygen(object):
   def output_print_lcov(p_stream, p_results):
     for c_file, c_data in p_results.items():
       p_stream.write("SF:%s\n" % c_file)
+      l_lines = {}
       for c_item in c_data:
-        l_value = 1
+        l_line = c_item["line"]
         if not c_item["documented"]:
-          l_value = 0
-        p_stream.write("DA:%d,%d\n" % (c_item["line"], l_value))
+          l_line[l_line] = 0
+        elif not l_line in l_lines:
+          l_lines[l_line] = 1
+      for c_line, c_lineValue in l_lines:
+        p_stream.write("DA:%d,%d\n" % (c_line, c_lineValue))
       p_stream.write("end_of_record\n")
 
 # Local Variables:

--- a/coverxygen/__main__.py
+++ b/coverxygen/__main__.py
@@ -56,21 +56,21 @@ def main():
                         default=None)
   l_parser.add_argument("--scope",
                         action="store",
-                        help="comma-separated list of items' scope to include : \n"
-                        " - public    : public member elements\n"
+                        help="comma-separated list of item scopes to include : \n"
+                        " - public    : public member and global elements\n"
                         " - protected : protected member elements\n"
                         " - private   : private member elements\n"
                         " - all       : all above\n",
                         default="all")
   l_parser.add_argument("--kind",
                         action="store",
-                        help="comma-separated list of items' type to include : \n"
+                        help="comma-separated list of item types to include : \n"
                         " - enum      : enum definitions\n"
-                        " - enumvalue : enumvalue definitions\n"
-                        "               Note: a single undocumented enumvalue will mark\n"
+                        " - enumvalue : enum value definitions\n"
+                        "               Note: a single undocumented enum value will mark\n"
                         "               the containing enum as undocumented\n"
-                        " - friend	: friend declarations\n"
-                        " - typedef   : typedef definitions\n"
+                        " - friend    : friend declarations\n"
+                        " - typedef   : type definitions\n"
                         " - variable  : variable definitions\n"
                         " - function  : function definitions\n"
                         " - signal    : Qt signal definitions\n"
@@ -79,9 +79,9 @@ def main():
                         " - struct    : struct definitions\n"
                         " - union     : union definitions\n"
                         " - define    : define definitions\n"
-                        " - file      : file definitions\n"
+                        " - file      : files\n"
                         " - namespace : namespace definitions\n"
-                        " - page      : page definitions\n"
+                        " - page      : documentation pages\n"
                         " - all       : all above\n",
                         default="all")
   l_result = l_parser.parse_args()

--- a/coverxygen/__main__.py
+++ b/coverxygen/__main__.py
@@ -47,7 +47,7 @@ def main():
                         required=True)
   l_parser.add_argument("--src-dir",
                         action="store",
-                        help ="root source directory used to match prefix for"
+                        help ="root source directory used to match prefix for "
                         "relative path generated files",
                         required=True)
   l_parser.add_argument("--prefix",

--- a/coverxygen/__main__.py
+++ b/coverxygen/__main__.py
@@ -65,6 +65,9 @@ def main():
                         action="store",
                         help="comma-separated list of items' type to include : \n"
                         " - enum      : enum definitions \n"
+                        " - enumvalue : enumvalue definitions\n"
+                        "               Note: a single undocumented enumvalue will mark\n"
+                        "               the containing enum as undocumented\n"
                         " - typedef   : typedef definitions\n"
                         " - variable  : variable definitions\n"
                         " - function  : function definitions\n"
@@ -81,7 +84,7 @@ def main():
   if l_result.scope == "all":
     l_result.scope = "public,protected,private"
   if l_result.kind == "all":
-    l_result.kind = "enum,typedef,variable,function,class,struct,define,file,namespace,page"
+    l_result.kind = "enum,enumvalue,typedef,variable,function,class,struct,define,file,namespace,page"
 
   l_result.scope = l_result.scope.split(",")
   l_result.kind  = l_result.kind.split(",")

--- a/coverxygen/__main__.py
+++ b/coverxygen/__main__.py
@@ -32,10 +32,14 @@ def main():
   l_parser.add_argument("--format",
                         action="store",
                         help="output file format : \n"
-                        "lcov        : lcov compatible format (default)\n"
-                        "json-legacy : legacy json format\n"
-                        "json        : simpler json format\n"
-                        "summary     : textual summary table format\n",
+                        "lcov         : lcov compatible format (default)\n"
+                        "json-v3      : json format which includes summary information\n"
+                        "json-v2      : simpler json format\n"
+                        "json-v1      : legacy json format\n"
+                        "json         : deprecated - same as json-v2\n"
+                        "json-legacy  : deprecated - same as json-v1\n"
+                        "json-summary : summary in json format\n"
+                        "summary      : textual summary table format\n",
                         default="lcov")
   l_parser.add_argument("--xml-dir",
                         action="store",
@@ -90,6 +94,13 @@ def main():
     l_result.scope = "public,protected,private"
   if l_result.kind == "all":
     l_result.kind = "enum,enumvalue,friend,typedef,variable,function,signal,slot,class,struct,union,define,file,namespace,page"
+
+  l_formatMapping = {
+    "json"       : "json-v2",
+    "json-legacy": "json-v1"
+  }
+  if l_result.format in l_formatMapping:
+    l_result.format = l_formatMapping[l_result.format]
 
   l_result.scope = l_result.scope.split(",")
   l_result.kind  = l_result.kind.split(",")

--- a/coverxygen/__main__.py
+++ b/coverxygen/__main__.py
@@ -34,7 +34,8 @@ def main():
                         help="output file format : \n"
                         "lcov        : lcov compatible format (default)\n"
                         "json-legacy : legacy json format\n"
-                        "json        : simpler json format\n",
+                        "json        : simpler json format\n"
+                        "summary     : textual summary table format\n",
                         default="lcov")
   l_parser.add_argument("--xml-dir",
                         action="store",

--- a/coverxygen/test/data/enum.xml
+++ b/coverxygen/test/data/enum.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="compound.xsd" version="1.8.14">
+  <compounddef
+    id="class_my_enum_class"
+    kind="class" language="C++" prot="public" abstract="yes">
+    <compoundname>MyEnumClass
+    </compoundname>
+    <sectiondef kind="public-type">
+      <memberdef kind="enum"
+        id="class_my_enum_class_1a4bffd5affc2abeba8ed3af3c2fd81ff4"
+        prot="public" static="no" strong="no">
+        <type></type>
+        <name>MyEnum</name>
+        <enumvalue
+          id="class_my_enum_class_1a4bffd5affc2abeba8ed3af3c2fd81ff4a38a848620f5abd0aca2849e48869ebc1"
+          prot="public">
+          <name>Enum_Value_1</name>
+          <initializer>= 100</initializer>
+          <briefdescription>
+            <para>A documented enum value. </para>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <enumvalue
+          id="class_my_enum_class_1a4bffd5affc2abeba8ed3af3c2fd81ff4a9f10ec475af2abef02c2eed24a376828"
+          prot="public">
+          <name>Enum_Value_2</name>
+          <initializer>= -1</initializer>
+          <briefdescription>
+          </briefdescription>
+          <detaileddescription>
+          </detaileddescription>
+        </enumvalue>
+        <briefdescription>
+          <para>An enumeration. </para>
+        </briefdescription>
+        <detaileddescription>
+        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="MyEnumClass.hpp" line="466" column="1" bodyfile="MyEnumClass.hpp" bodystart="465" bodyend="475" />
+      </memberdef>
+    </sectiondef>
+  </compounddef>
+</doxygen>

--- a/coverxygen/test/test_coverxygen.py
+++ b/coverxygen/test/test_coverxygen.py
@@ -320,12 +320,12 @@ class CoverxygenTest(unittest.TestCase):
     l_obj = Coverxygen(None, None, [], [], None, None, None, False)
     l_stream = StringIO()
     l_results = {}
-    l_symbols = [{'documented': True, 'line': 466, 'symbol': 'MyEnum', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
+    l_symbols = [{'documented': True,  'line': 466, 'symbol': 'MyEnum', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
                  {'documented': False, 'line': 466, 'symbol': 'Enum_Value_1', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
-                 {'documented': True, 'line': 466, 'symbol': 'Enum_Value_2', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
-                 {'documented': True, 'line': 17, 'symbol': 'MyOtherEnum', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')},
-                 {'documented': True, 'line': 17, 'symbol': 'OtherEnum_Value_1', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')},
-                 {'documented': True, 'line': 17, 'symbol': 'OtherEnum_Value_2', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')}]
+                 {'documented': True,  'line': 466, 'symbol': 'Enum_Value_2', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
+                 {'documented': True,  'line': 17,  'symbol': 'MyOtherEnum', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')},
+                 {'documented': True,  'line': 17,  'symbol': 'OtherEnum_Value_1', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')},
+                 {'documented': True,  'line': 17,  'symbol': 'OtherEnum_Value_2', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')}]
     l_results = l_obj.group_symbols_by_file(l_symbols)
     l_obj.output_print_lcov(l_stream, l_results)
     l_outputResult = l_stream.getvalue()
@@ -335,3 +335,20 @@ class CoverxygenTest(unittest.TestCase):
     self.assertNotIn("DA:466,1", l_outputResult)
     self.assertNotIn("DA:17,0", l_outputResult)
     self.assertIn("DA:17,1", l_outputResult)
+
+  def test_output_print_summary(self):
+    l_obj = Coverxygen(None, None, [], [], None, None, None, False)
+    l_stream = StringIO()
+    l_symbols = [{'documented': True,  'line': 466, 'kind': 'enum', 'symbol': 'MyEnum', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
+                 {'documented': False, 'line': 466, 'kind': 'enumvalue', 'symbol': 'Enum_Value_1', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
+                 {'documented': True,  'line': 466, 'kind': 'enumvalue', 'symbol': 'Enum_Value_2', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
+                 {'documented': True,  'line': 17,  'kind': 'enum', 'symbol': 'MyOtherEnum', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')},
+                 {'documented': True,  'line': 17,  'kind': 'enumvalue', 'symbol': 'OtherEnum_Value_1', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')},
+                 {'documented': True,  'line': 17,  'kind': 'enumvalue', 'symbol': 'OtherEnum_Value_2', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')}]
+    l_obj.output_print_summary(l_stream, l_symbols)
+    l_outputResult = l_stream.getvalue()
+    l_stream.close()
+
+    self.assertRegexpMatches(l_outputResult, r".*Enums\s*:\s+100\.0% \(2/2\).*")
+    self.assertRegexpMatches(l_outputResult, r".*Enum Values\s*:\s+75\.0% \(3/4\).*")
+    self.assertRegexpMatches(l_outputResult, r".*Total\s*:\s+83\.3% \(5/6\).*")

--- a/coverxygen/test/test_coverxygen.py
+++ b/coverxygen/test/test_coverxygen.py
@@ -243,16 +243,15 @@ class CoverxygenTest(unittest.TestCase):
 
 
 
-  def test_merge_symbol(self):
-    l_syms   = [{ "file" : "a", "key1" : 1}]
-    l_res    = {}
-    l_expect = { "a" : [ { "file" : "a", "key1" : 1} ] }
-    Coverxygen.merge_symbols(l_res, l_syms)
+  def test_group_symbols_by_file(self):
+    l_syms   = [{ "file" : "a", "key1" : 1 }]
+    l_expect = { "a" : [ { "file" : "a", "key1" : 1 } ] }
+    l_res = Coverxygen.group_symbols_by_file(l_syms)
     self.assertDictEqual(l_expect, l_res)
 
     l_syms   = [
-      { "file" : "a", "key1" : 1},
-      { "file" : "a", "key2" : 2}
+      { "file" : "a", "key1" : 1 },
+      { "file" : "a", "key2" : 2 }
     ]
     l_expect = {
       "a" : [
@@ -260,44 +259,39 @@ class CoverxygenTest(unittest.TestCase):
         { "file" : "a", "key2" : 2 }
       ]
     }
-    l_res = {}
-    Coverxygen.merge_symbols(l_res, l_syms)
+    l_res = Coverxygen.group_symbols_by_file(l_syms)
     self.assertDictEqual(l_expect, l_res)
 
     l_syms   = [
-      { "file" : "b", "key1" : 1},
-      { "file" : "c", "key2" : 2}
+      { "file" : "b", "key1" : 1 },
+      { "file" : "c", "key2" : 2 }
     ]
     l_expect = {
       "b" : [{ "file" : "b", "key1" : 1 }],
       "c" : [{ "file" : "c", "key2" : 2 }]
     }
-    l_res = {}
-    Coverxygen.merge_symbols(l_res, l_syms)
+    l_res = Coverxygen.group_symbols_by_file(l_syms)
     self.assertDictEqual(l_expect, l_res)
 
     l_syms   = [
-      { "file" : "b", "key1" : 1},
-      { "file" : "c", "key2" : 2}
+      { "file" : "b", "key1" : 1 },
+      { "file" : "c", "key2" : 2 },
+      { "file" : "b", "key0" : 0 }
     ]
     l_expect = {
       "b" : [{ "file" : "b", "key0" : 0 }, { "file" : "b", "key1" : 1 }],
       "c" : [{ "file" : "c", "key2" : 2 }]
     }
-    l_res = {
-      "b" : [{ "file" : "b", "key0" : 0 }]
-    }
-    Coverxygen.merge_symbols(l_res, l_syms)
+    l_res = Coverxygen.group_symbols_by_file(l_syms)
     self.assertDictEqual(l_expect, l_res)
 
-    l_syms   = []
+    l_syms   = [
+      { "file" : "b", "key0" : 0 }
+    ]
     l_expect = {
       "b" : [{ "file" : "b", "key0" : 0 }],
     }
-    l_res = {
-      "b" : [{ "file" : "b", "key0" : 0 }]
-    }
-    Coverxygen.merge_symbols(l_res, l_syms)
+    l_res = Coverxygen.group_symbols_by_file(l_syms)
     self.assertDictEqual(l_expect, l_res)
 
 
@@ -337,7 +331,7 @@ class CoverxygenTest(unittest.TestCase):
                  {'documented': True, 'line': 17, 'symbol': 'MyOtherEnum', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')},
                  {'documented': True, 'line': 17, 'symbol': 'OtherEnum_Value_1', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')},
                  {'documented': True, 'line': 17, 'symbol': 'OtherEnum_Value_2', 'file': os.path.abspath('/opt/MyOtherEnumClass.hpp')}]
-    l_obj.merge_symbols(l_results, l_symbols)
+    l_results = l_obj.group_symbols_by_file(l_symbols)
     l_obj.output_print_lcov(l_stream, l_results)
     l_outputResult = l_stream.getvalue()
     l_stream.close()

--- a/coverxygen/test/test_coverxygen.py
+++ b/coverxygen/test/test_coverxygen.py
@@ -217,7 +217,7 @@ class CoverxygenTest(unittest.TestCase):
     l_node   = l_classDoc.find("./compounddef//memberdef[@id='classxtd_1_1Application_1a672c075ed901e463609077d571a714c7']")
     l_obj    = Coverxygen(None, None, l_scopes, l_kinds, "/opt", None, "/opt", False)
     l_data   = l_obj.process_symbol(l_node, "/opt/file.hh")
-    l_expect = [{'documented': True, 'line': 102, 'symbol': 'argument', 'file': os.path.abspath('/opt/src/Application.hh')}]
+    l_expect = [{'documented': True, 'line': 102, 'kind': 'enum', 'symbol': 'argument', 'file': os.path.abspath('/opt/src/Application.hh')}]
     self.assertEqual(l_expect, l_data)
 
     l_node     = l_classDoc.find("./compounddef//memberdef[@id='classxtd_1_1Application_1a907b6fe8247636495890e668530863d6']")
@@ -229,16 +229,16 @@ class CoverxygenTest(unittest.TestCase):
     l_node         = l_namesapceDoc.find("./compounddef[@id='namespace_my_namespace']")
     l_obj          = Coverxygen(None, None, l_scopes, l_kinds, "/opt", None, "/opt", False)
     l_data         = l_obj.process_symbol(l_node, "/opt/file.hh")
-    l_expect       = [{'documented': True, 'line': 5, 'symbol': 'MyNamespace', 'file': os.path.abspath('/opt/src/MyNamespace.hh')}]
+    l_expect       = [{'documented': True, 'line': 5, 'kind': 'namespace', 'symbol': 'MyNamespace', 'file': os.path.abspath('/opt/src/MyNamespace.hh')}]
     self.assertEqual(l_expect, l_data)
 
     l_enumDoc = ET.parse(self.get_data_path("enum.xml"))
     l_node    = l_enumDoc.find("./compounddef//memberdef[@id='class_my_enum_class_1a4bffd5affc2abeba8ed3af3c2fd81ff4']")
     l_obj     = Coverxygen(None, None, l_scopes, ["enum", "enumvalue"], "/opt", None, "/opt", False)
     l_data    = l_obj.process_symbol(l_node, "/opt/file.hh")
-    l_expect  = [{'documented': True, 'line': 466, 'symbol': 'MyEnum', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
-                 {'documented': True, 'line': 466, 'symbol': 'Enum_Value_1', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
-                 {'documented': False, 'line': 466, 'symbol': 'Enum_Value_2', 'file': os.path.abspath('/opt/MyEnumClass.hpp')}]
+    l_expect  = [{'documented': True, 'line': 466, 'kind': 'enum', 'symbol': 'MyEnum', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
+                 {'documented': True, 'line': 466, 'kind': 'enumvalue', 'symbol': 'Enum_Value_1', 'file': os.path.abspath('/opt/MyEnumClass.hpp')},
+                 {'documented': False, 'line': 466, 'kind': 'enumvalue', 'symbol': 'Enum_Value_2', 'file': os.path.abspath('/opt/MyEnumClass.hpp')}]
     self.assertEqual(l_expect, l_data)
 
 
@@ -278,7 +278,7 @@ class CoverxygenTest(unittest.TestCase):
       { "file" : "b", "key0" : 0 }
     ]
     l_expect = {
-      "b" : [{ "file" : "b", "key0" : 0 }, { "file" : "b", "key1" : 1 }],
+      "b" : [{ "file" : "b", "key1" : 1 }, { "file" : "b", "key0" : 0 }],
       "c" : [{ "file" : "c", "key2" : 2 }]
     }
     l_res = Coverxygen.group_symbols_by_file(l_syms)
@@ -295,29 +295,25 @@ class CoverxygenTest(unittest.TestCase):
 
 
   def test_process_file(self):
-    l_file   = self.get_data_path("class.xml")
+    l_testDataFile   = self.get_data_path("class.xml")
     l_scopes = ["private",  "protected", "public"]
     l_kinds  = ["enum"]
     l_obj    = Coverxygen(None, None, l_scopes, l_kinds, "/opt", None, "/opt", False)
-    l_res    = {}
-    l_name   = os.path.abspath("/opt/src/Application.hh")
-    l_obj.process_file(l_file, l_res)
-    self.assertEqual(1, len(l_res.keys()))
-    self.assertIn(l_name, l_res)
-    self.assertEqual(2, len(l_res[l_name]))
-    self.assertEqual(2, len([x for x in l_res[l_name] if x['documented']]))
+    l_file   = os.path.abspath("/opt/src/Application.hh")
+    l_symbols = l_obj.process_file(l_testDataFile)
+    self.assertEqual(2, len(l_symbols))
+    self.assertEqual(2, len([x for x in l_symbols if x['file'] == l_file]))
+    self.assertEqual(2, len([x for x in l_symbols if x['documented']]))
 
-    l_file   = self.get_data_path("class.xml")
+    l_testDataFile   = self.get_data_path("class.xml")
     l_scopes = ["private",  "protected", "public"]
     l_kinds  = ["class"]
     l_obj    = Coverxygen(None, None, l_scopes, l_kinds, "/opt", None, "/opt", False)
-    l_res    = {}
-    l_name   = os.path.abspath("/opt/src/Application.hh")
-    l_obj.process_file(l_file, l_res)
-    self.assertEqual(1, len(l_res.keys()))
-    self.assertIn(l_name, l_res)
-    self.assertEqual(1, len(l_res[l_name]))
-    self.assertEqual(1, len([x for x in l_res[l_name] if x['documented']]))
+    l_file   = os.path.abspath("/opt/src/Application.hh")
+    l_symbols = l_obj.process_file(l_testDataFile)
+    self.assertEqual(1, len(l_symbols))
+    self.assertEqual(1, len([x for x in l_symbols if x['file'] == l_file]))
+    self.assertEqual(1, len([x for x in l_symbols if x['documented']]))
 
 
   def test_output_print_lvoc(self):


### PR DESCRIPTION
Using LCOV to calculate the coverage has one drawback: the coverage is based on lines.
This makes the coverage inaccurate when there are multiple symbols defined on the same line and also when including enum values in the coverage calculation since Doxygen doesn't provide location information for them (see #12).

This PR adds a new output format: "summary".
It calculates the coverage per symbol type and in total and prints a table listing the results like this:
```
Classes    :  90.5% (38/42)
Defines    :   0.0% (0/2)
Enum Values:  12.3% (8/65)
Enums      :  75.0% (3/4)
Files      :   8.3% (2/24)
Functions  :  64.8% (175/270)
Namespaces :  75.0% (6/8)
Pages      : 100.0% (7/7)
Signals    :  83.3% (5/6)
Slots      :  28.6% (2/7)
Structs    :  80.0% (4/5)
Typedefs   :  39.1% (9/23)
Variables  :  20.0% (8/40)
-----------------------------------
Total      :  53.1% (267/503)
```


This PR also changes the "json" and "json-legacy" output formats slightly: it adds a "kind" property to the symbol information:
```json
[...]
    {
      "symbol": "Tests::ManagerTest",
      "documented": true,
      "kind": "class",
      "line": 18,
      "file": "/path/to/ManagerTest.cpp"
    },
[...]
```
IMO, that change is backward compatible. However, if someone relies on the exact format of the JSON, then this will break it of course.
So if you think the JSON formats should not be changed, then I can filter the "kind" property out, of course. Just let me know.

PS: I will create another PR to add options to exclude/include files using regular expressions to allow more fine grained control over what is included in the coverage calculation.