### PR TITLE
Added option exclude symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ debian/python-coverxygen.postinst.debhelper
 debian/python-coverxygen.prerm.debhelper
 
 .debhelper
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -72,64 +72,67 @@ python3 -m coverxygen --xml-dir <path_to_doxygen_xml_dir> --src-dir <path_to_roo
 ```
 
 Full usage :
+
 ```
-usage: coverxygen [-h] [--version] [--verbose] [--json] [--format FORMAT]
-                  [--prefix PREFIX] [--exclude EXCLUDE] [--include INCLUDE]
-                  [--scope SCOPE] [--kind KIND] --xml-dir XML_DIR --output
-                  OUTPUT --src-dir SRC_DIR
+usage: coverxygen [-h] [--version] [--verbose] [--json] [--format FORMAT] [--prefix PREFIX] [--exclude EXCLUDE] [--include INCLUDE]
+                  [--excludesymbols EXCLUDESYMBOLS] [--scope SCOPE] [--kind KIND] --xml-dir XML_DIR --output OUTPUT --src-dir SRC_DIR
 
 required arguments:
-  --xml-dir XML_DIR  path to generated doxygen XML directory
-  --output OUTPUT    destination output file (- for stdout)
-  --src-dir SRC_DIR  root source directory used to match prefix for relative path generated files
+  --xml-dir XML_DIR     path to generated doxygen XML directory
+  --output OUTPUT       destination output file (- for stdout)
+  --src-dir SRC_DIR     root source directory used to match prefix for relative path generated files
 
 optional arguments:
-  -h, --help         show this help message and exit
-  --version          print version and exit
-  --verbose          enabled verbose output
-  --json             (deprecated) same as --format json-legacy
-  --format FORMAT    output file format :
-                     lcov             : lcov compatible format (default)
-                     json-v3          : json format which includes summary information
-                     json-v2          : simpler json format
-                     json-v1          : legacy json format
-                     json             : (deprecated) same as json-v2
-                     json-legacy      : (deprecated) same as json-v1
-                     json-summary     : summary in json format
-                     markdown-summary : ummary in markdown table format
-                     summary          : textual summary table format
-  --prefix PREFIX    keep only file matching given path prefix
-  --exclude EXCLUDE  exclude files whose absolute path matches a regular expression;
-                     this option can be given multiple times
-  --include INCLUDE  include files whose absolute path matches a regular expression
-                     even if they also match an exclude filter (see --exclude) or if they
-                     are not matching the patch prefix (see --prefix);
-                     this option can be given multiple times
-  --scope SCOPE      comma-separated list of item scopes to include :
-                      - public    : public member and global elements
-                      - protected : protected member elements
-                      - private   : private member elements
-                      - all       : all above
-  --kind KIND        comma-separated list of item types to include :
-                      - enum      : enum definitions
-                      - enumvalue : enum value definitions
-                                    Note: a single undocumented enum value will mark
-                                    the containing enum as undocumented
-                      - friend    : friend declarations
-                      - typedef   : type definitions
-                      - variable  : variable definitions
-                      - function  : function definitions
-                      - signal    : Qt signal definitions
-                      - slot      : Qt slot definitions
-                      - class     : class definitions
-                      - struct    : struct definitions
-                      - union     : union definitions
-                      - define    : define definitions
-                      - file      : files
-                      - namespace : namespace definitions
-                      - page      : documentation pages
-                      - all       : all above
-
+  -h, --help            show this help message and exit
+  --version             print version and exit
+  --verbose             enabled verbose output
+  --json                (deprecated) same as --format json-legacy
+  --format FORMAT       output file format :
+                        lcov             : lcov compatible format (default)
+                        json-v3          : json format which includes summary information
+                        json-v2          : simpler json format
+                        json-v1          : legacy json format
+                        json             : (deprecated) same as json-v2
+                        json-legacy      : (deprecated) same as json-v1
+                        json-summary     : summary in json format
+                        markdown-summary : summary in markdown table format
+                        summary          : textual summary table format
+  --prefix PREFIX       keep only file matching given path prefix
+  --exclude EXCLUDE     exclude files whose absolute path matches the given regular expression <EXLUDE>;
+                        this option can be given multiple times
+  --include INCLUDE     include files whose absolute path matches the given regular expression <INCLUDE>
+                        even if they also match an exclude filter (see --exclude) or if they
+                        are not matching the patch prefix (see --prefix);
+                        this option can be given multiple times
+  --excludesymbols EXCLUDESYMBOLS
+                        exclude symbols which match the given regular expression <EXCLUDESYMBOLS>
+                        note that symbols are only matched against their fully qualified name if such is
+                        used in the regex. Also, Doxygen uses the "ref with var" convention (`int &a`);
+                        this option can be given multiple times
+  --scope SCOPE         comma-separated list of item scopes to include :
+                         - public    : public member and global elements
+                         - protected : protected member elements
+                         - private   : private member elements
+                         - all       : all above
+  --kind KIND           comma-separated list of item types to include : 
+                         - enum      : enum definitions
+                         - enumvalue : enum value definitions
+                                       Note: a single undocumented enum value will mark
+                                       the containing enum as undocumented
+                         - friend    : friend declarations
+                         - typedef   : type definitions
+                         - variable  : variable definitions
+                         - function  : function definitions
+                         - signal    : Qt signal definitions
+                         - slot      : Qt slot definitions
+                         - class     : class definitions
+                         - struct    : struct definitions
+                         - union     : union definitions
+                         - define    : define definitions
+                         - file      : files
+                         - namespace : namespace definitions
+                         - page      : documentation pages
+                         - all       : all above
 ```
 
 ## Run lcov or genhtml

--- a/coverxygen/__main__.py
+++ b/coverxygen/__main__.py
@@ -60,6 +60,13 @@ def main():
                               "are not matching the patch prefix (see --prefix);\n"
                               "this option can be given multiple times",
                               default=[])
+  l_optionalArgs.add_argument("--excludesymbols",
+                              action="append",
+                              help="exclude symbols which match the given regular expression <EXCLUDESYMBOLS>\n"
+                              "note that symbols are only matched against their fully qualified name if such is\n"
+                              "used in the regex. Also, Doxygen uses the \"ref with var\" convention (`int &a`);\n"
+                              "this option can be given multiple times",
+                              default=[])
   l_optionalArgs.add_argument("--scope",
                               action="store",
                               help="comma-separated list of item scopes to include :\n"

--- a/coverxygen/test/test_coverxygen.py
+++ b/coverxygen/test/test_coverxygen.py
@@ -9,7 +9,7 @@ import os
 import json
 import tempfile
 import xml.etree.ElementTree as ET
-import unittest2 as unittest
+import unittest
 from io import StringIO
 from coverxygen import Coverxygen
 
@@ -432,6 +432,6 @@ class CoverxygenTest(unittest.TestCase):
     l_outputResult = l_stream.getvalue()
     l_stream.close()
 
-    self.assertRegexpMatches(l_outputResult, r".*Enums\s*:\s+100\.0% \(2/2\).*")
-    self.assertRegexpMatches(l_outputResult, r".*Enum Values\s*:\s+75\.0% \(3/4\).*")
-    self.assertRegexpMatches(l_outputResult, r".*Total\s*:\s+83\.3% \(5/6\).*")
+    self.assertRegex(l_outputResult, r".*Enums\s*:\s+100\.0% \(2/2\).*")
+    self.assertRegex(l_outputResult, r".*Enum Values\s*:\s+75\.0% \(3/4\).*")
+    self.assertRegex(l_outputResult, r".*Total\s*:\s+83\.3% \(5/6\).*")

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-unittest2
+unittest
 requests
 coverage
 coveralls


### PR DESCRIPTION
Hi Xavier

I've been using coverxygen for some years in a "documentation coverage gate" in build pipelines. Since I did not want this gate to annoy devs and force them to write docu for self-evident functions -- commenting "this is the default constructor" does not add any value.

Therefore, I've extended coverxygen to support a new `--excludesymbols` option. 
As another example, I'm using this regex to exclude any function that starts with get, set, is, has, can: `.*[:|_][get|set|is|has|can]([A-Za-z0-9_-]+)\(.*\).*`
 
 I've added relatively thorough tests that use your `class.xml` test data and have updated the README with the output from `--help`.

Let me know if I missed anything,
Lorenz